### PR TITLE
removing date header from router

### DIFF
--- a/server/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/server/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -275,6 +275,9 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
     request.setAttribute(SCHEME_ATTRIBUTE, targetServer.getScheme());
 
     doService(request, response);
+    if (response != null && response.getHeader("Date") != null) {
+      response.setHeader("Date", null);
+    }
   }
 
   protected void doService(

--- a/server/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
+++ b/server/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
@@ -201,6 +201,13 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
 
     final HttpServletRequest requestMock = EasyMock.createMock(HttpServletRequest.class);
     final ByteArrayInputStream inputStream = new ByteArrayInputStream(jsonMapper.writeValueAsBytes(query));
+
+    final HttpServletResponse responseMock = EasyMock.createMock(HttpServletResponse.class);
+    EasyMock.expect(responseMock.getHeader("Date")).andReturn("2020-02-02");
+    responseMock.setHeader("Date", null);
+    EasyMock.expectLastCall();
+    EasyMock.replay(responseMock);
+
     final ServletInputStream servletInputStream = new ServletInputStream()
     {
       private boolean finished;
@@ -269,7 +276,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
       }
     };
 
-    servlet.service(requestMock, null);
+    servlet.service(requestMock, responseMock);
 
     // This test is mostly about verifying that the servlet calls the right methods the right number of times.
     EasyMock.verify(hostFinder, requestMock);


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Is for https://github.com/apache/druid/issues/8252

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Removed the header from Router class which made date header come twice in an API request.



<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->



##### Key changed/added classes in this PR
 * main/.../server/AsyncQueryForwardingServlet.java
 * test/.../server/AsyncQueryForwardingServletTest.java  
 